### PR TITLE
Added unit tests for property fields

### DIFF
--- a/anki-editor-tests.el
+++ b/anki-editor-tests.el
@@ -169,7 +169,7 @@ Simple note body
         (anki-editor-test--teardown)))))
 
 
-(ert-deftest test--node-at-point-for-note-with-property-field-should-render-property-field ()
+(ert-deftest test--note-at-point-for-note-with-property-field-should-render-property-field ()
   "Test `anki-editor--note-at-point' should render property field."
   (save-window-excursion
     (with-current-buffer (anki-editor-test--test-org-buffer "property-fields.org")
@@ -184,7 +184,7 @@ Simple note body
                                        nil)))
         (anki-editor-test--teardown)))))
 
-(ert-deftest test--node-at-point-for-note-with-property-field-should-override-subheading-field ()
+(ert-deftest test--note-at-point-for-note-with-property-field-should-override-subheading-field ()
   "Test `anki-editor--note-at-point' should override subheading field."
   (save-window-excursion
     (with-current-buffer (anki-editor-test--test-org-buffer "property-fields.org")
@@ -200,7 +200,7 @@ Simple note body
         (anki-editor-test--teardown)))))
 
 
-(ert-deftest test--node-at-point-for-note-with-unknown-property-field-should-raise-error ()
+(ert-deftest test--note-at-point-for-note-with-unknown-property-field-should-raise-error ()
   "Test `anki-editor--note-at-point' should raise error for unknown property field."
   (save-window-excursion
     (with-current-buffer (anki-editor-test--test-org-buffer "property-fields.org")

--- a/anki-editor-tests.el
+++ b/anki-editor-tests.el
@@ -82,6 +82,7 @@ Origian values are stored in
 You can restore the original values by calling
 `anki-editor-test--restore-variables'."
   (cl-loop for (variable . value) in variables
+           when (boundp variable)
            do (push (cons variable (symbol-value variable)) anki-editor-test--saved-variable-values)
            do (set variable value)))
 
@@ -167,6 +168,50 @@ Simple note body
 ")) nil)))
         (anki-editor-test--teardown)))))
 
+
+(ert-deftest test--node-at-point-for-note-with-property-field-should-render-property-field ()
+  "Test `anki-editor--note-at-point' should render property field."
+  (save-window-excursion
+    (with-current-buffer (anki-editor-test--test-org-buffer "property-fields.org")
+      (anki-editor-test--go-to-headline "\"Front\" property field")
+      (anki-editor-test--setup)
+      (unwind-protect
+          (should (equal
+                   (anki-editor-note-at-point)
+                   #s(anki-editor-note nil "Basic" "Tests"
+                                       (("Back" . "<p>\nShould be included\n</p>\n")
+                                        ("Front" . "<p>\nCan one define an anki-field inside an org-mode property?</p>\n"))
+                                       nil)))
+        (anki-editor-test--teardown)))))
+
+(ert-deftest test--node-at-point-for-note-with-property-field-should-override-subheading-field ()
+  "Test `anki-editor--note-at-point' should override subheading field."
+  (save-window-excursion
+    (with-current-buffer (anki-editor-test--test-org-buffer "property-fields.org")
+      (anki-editor-test--go-to-headline "\"Front\" property field with \"Front\" subheading")
+      (anki-editor-test--setup)
+      (unwind-protect
+          (should (equal
+                   (anki-editor-note-at-point)
+                   #s(anki-editor-note nil "Basic" "Tests"
+                                       (("Back" . "<p>\nShould be included\n</p>\n")
+                                        ("Front" . "<p>\nCan one define an anki-field inside an org-mode property?</p>\n"))
+                                       nil)))
+        (anki-editor-test--teardown)))))
+
+
+(ert-deftest test--node-at-point-for-note-with-unknown-property-field-should-raise-error ()
+  "Test `anki-editor--note-at-point' should raise error for unknown property field."
+  (save-window-excursion
+    (with-current-buffer (anki-editor-test--test-org-buffer "property-fields.org")
+      (anki-editor-test--go-to-headline "Foreign property field")
+      (anki-editor-test--setup)
+      (unwind-protect
+          (should
+           (equal
+            (should-error (anki-editor-note-at-point) :type 'user-error)
+            ' (user-error "Failed to map all named fields")))
+        (anki-editor-test--teardown)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; anki-editor-tests.el ends here

--- a/test-files/property-fields.org
+++ b/test-files/property-fields.org
@@ -1,0 +1,37 @@
+* "Front" property field
+:PROPERTIES:
+:ANKI_NOTE_TYPE: Basic
+:ANKI_FIELD_FRONT: Can one define an anki-field inside an org-mode property?
+:ANKI_PREPEND_HEADING: nil
+:ANKI_DECK: Tests
+:END:
+
+** Back
+Should be included
+
+* "Front" property field with "Front" subheading
+:PROPERTIES:
+:ANKI_NOTE_TYPE: Basic
+:ANKI_FIELD_FRONT: Can one define an anki-field inside an org-mode property?
+:ANKI_PREPEND_HEADING: nil
+:ANKI_DECK: Tests
+:END:
+
+** Front
+Should not be included
+
+** Back
+Should be included
+
+
+* Foreign property field
+:ANKI_NOTE_TYPE: Basic
+:ANKI_FIELD_FOREIGN: Should raise error
+:ANKI_PREPEND_HEADING: nil
+:ANKI_DECK: Tests
+
+** Front
+front
+
+** Back
+back


### PR DESCRIPTION
#27 has a huge refactoring, so I want to have unit tests in place for the old code to ensure that I don't break anything with the refactoring. 

In addition - this PR fixes unit-tests for emacs 26

