### PR TITLE
Inherit anki-editor-prop-note-type from parent

### DIFF
--- a/anki-editor.el
+++ b/anki-editor.el
@@ -780,7 +780,7 @@ and else from variable `anki-editor-prepend-heading'."
          (format (anki-editor-entry-format))
          (prepend-heading (anki-editor-prepend-heading))
          (note-id (org-entry-get nil anki-editor-prop-note-id))
-         (note-type (or (org-entry-get nil anki-editor-prop-note-type)
+         (note-type (or (org-entry-get-with-inheritance anki-editor-prop-note-type)
                         anki-editor-default-note-type))
          (tags (cl-set-difference (anki-editor--get-tags)
                                   anki-editor-ignored-org-tags


### PR DESCRIPTION
Thank you for `anki-editor`!  I am a new user of Anki, and I'm creating my first deck, in which I want all notes to have `:ANKI_NOTE_TYPE: Basic (and reversed card)`.  Is there some reason why this property shouldn't be inherited to avoid duplication?