### PR TITLE
Allows setting note deck with anki editor ui

### DIFF
--- a/anki-editor-ui.el
+++ b/anki-editor-ui.el
@@ -51,6 +51,7 @@
    [""
     ("I" " insert note" anki-editor-insert-note :level 1)
     ("T" " set note type" anki-editor-set-note-type :level 1)
+    ("D" " set note deck" anki-editor-set-deck :level 1)
     ("d" " delete note" anki-editor-delete-note-at-point :level 1)]]
   [["Push"
     ("." " note at point        " anki-editor-push-note-at-point :level 2)

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -1319,6 +1319,31 @@ When NOTE-TYPE is nil, prompt for one."
          nil
        'tree))))
 
+
+(defun anki-editor-set-deck (&optional prefix note-deck)
+  "Set deck for current or closest previous heading.
+With PREFIX set note type for all top-level headings in subtree.
+When NOTE-DECK is nil, prompt for one."
+  (interactive "P")
+  (let ((note-deck
+         (or note-deck
+             (completing-read "Note deck: "
+                              (sort (anki-editor-deck-names) #'string-lessp)
+                              nil
+                              nil
+                              (org-entry-get-with-inheritance anki-editor-prop-deck))))
+        (level
+         (if prefix
+             (+ 1 (or (org-current-level) 0))
+           (or (org-current-level) 0))))
+    (org-map-entries
+     (lambda () (org-set-property anki-editor-prop-deck note-deck))
+     (concat "LEVEL=" (number-to-string level))
+     (if (and prefix
+              (equal 1 level))
+         nil
+       'tree))))
+
 (defun anki-editor-set-default-note-type (&optional prefix)
   "Set default note type for current or closest previous heading.
 The note type is taken from the ANKI_DEFAULT_NOTE_TYPE property,


### PR DESCRIPTION
1. Prompts for a deck name which could be selected from existing ones
2. Pre-fills deck name if it's already set for a note