### PR TITLE
Misc Performance Improvements

### DIFF
--- a/anki-editor-tests.el
+++ b/anki-editor-tests.el
@@ -169,7 +169,7 @@ Lorem
                                         ("Front" . "<p>
 Simple note body
 </p>
-")) nil)))
+")) nil nil nil)))
         (anki-editor-test--teardown)))))
 
 
@@ -185,7 +185,7 @@ Simple note body
                    #s(anki-editor-note nil "Basic" "Tests"
                                        (("Back" . "<p>\nShould be included\n</p>\n")
                                         ("Front" . "<p>\nCan one define an anki-field inside an org-mode property?</p>\n"))
-                                       nil)))
+                                       nil nil nil)))
         (anki-editor-test--teardown)))))
 
 (ert-deftest test--note-at-point-for-note-with-property-field-should-override-subheading-field ()
@@ -200,7 +200,7 @@ Simple note body
                    #s(anki-editor-note nil "Basic" "Tests"
                                        (("Back" . "<p>\nShould be included\n</p>\n")
                                         ("Front" . "<p>\nCan one define an anki-field inside an org-mode property?</p>\n"))
-                                       nil)))
+                                       nil nil nil)))
         (anki-editor-test--teardown)))))
 
 
@@ -211,47 +211,47 @@ Simple note body
                                 nil "Cloze" "Default"
                                 (("Back Extra" . "<p>\nDeck in file</p>\n")
                                  ("Text" . "<p>\nCards of this note will be created in {{c1::Default::which deck?}}\n</p>\n"))
-                                nil))
+                                nil nil nil))
            ("Deck in entry" . #s(anki-editor-note
                                  nil "Cloze" "Languages"
                                  (("Back Extra" . "<p>\nDeck in entry</p>\n")
                                   ("Text" . "<p>\nCards of this note will be created in {{c1::Languages::which deck?}}\n</p>\n"))
-                                 nil))
+                                 nil nil nil))
            ("Raw fields" . #s(anki-editor-note
                               nil "Basic" "Default"
                               (("Back" . "<p>\nWith property &lt;code&gt;:ANKI<sub>FORMAT</sub>: nil&lt;/code&gt;, content of the\nfield will be sent to Anki &lt;em&gt;unprocessed&lt;/em&gt;.  You can use\nwhatever Anki supports, like HTML tags.\n&lt;br&gt;\n&lt;br&gt;\nThis property is retrieved with inheritance, meaning that it can be\nset in any ancestor entries or at the top of the file with\n&lt;code&gt;#+PROPERTY: ANKI<sub>FORMAT</sub> nil&lt;/code&gt;, it's also possible to\noverride an outer level nil format with &lt;code&gt;:ANKI<sub>FORMAT</sub>: t&lt;/code&gt;.\n</p>\n")
                                ("Front" . "<p>\nHow to send the content of a field or fields to Anki as is?\n</p>\n"))
-                              nil))
+                              nil nil nil))
            ("Is there a shorter way to write notes?" . #s(anki-editor-note
                                                           nil "Basic" "Default"
                                                           (("Back" . "<p>\nYes, like this one, Front is missing, <code>anki-editor</code> will use note\nheading as Front.  This is neat as sometimes it's verbose to repeat\nthe same content in note heading and first field.\n</p>\n\n<p>\nThis works for all note types, just make one field absent and\n<code>anki-editor</code> will use note heading as that missing field.\n</p>\n")
                                                            ("Front" . "<p>\nIs there a shorter way to write notes?</p>\n"))
-                                                          nil))
+                                                          nil nil nil))
            ("Raining" . #s(anki-editor-note
                            nil "Basic (and reversed card)" "Languages"
                            (("Back" . "<p>\nit's raining very hard\n</p>\n")
                             ("Front" . "<p>\n(it's) raining cats and dogs\n</p>\n"))
-                           ("vocab" "idioms" "english")))
+                           ("vocab" "idioms" "english") nil nil))
            ("名词从句" . #s(anki-editor-note
                             nil "Basic" "Languages"
                             (("Back" . "<ol class=\"org-ol\">\n<li>That + 一个完整的句子, that无实际意义</li>\n<li>由疑问句改装而成</li>\n</ol>\n")
                              ("Front" . "<p>\n名词从句有哪些形式？\n</p>\n"))
-                            ("grammar" "english")))
+                            ("grammar" "english") nil nil))
            ("Cantonese" . #s(anki-editor-note
                              nil "Basic (and reversed card)" "Languages"
                              (("Back" . "<p>\n吃过饭了没？\n</p>\n")
                               ("Front" . "<p>\n食咗饭未吖？\n</p>\n"))
-                             ("cantonese" "dialect")))
+                             ("cantonese" "dialect") nil nil))
            ("Emacs Lisp" . #s(anki-editor-note
                               nil "Basic" "Computing"
                               (("Back" . "<div align=\"left\">\n\n<div class=\"org-src-container\">\n<pre class=\"src src-emacs-lisp\">(condition-case the-error\n    ;; the protected form\n    (progn\n      (do-something-dangerous)\n      (do-something-more-dangerous))\n  ;; handlers\n  (error-symbol1 (handler1 the-error))\n  ((error-symbol2 error-symbol3 (handler the-error))))\n</pre>\n</div>\n\n</div>\n")
                                ("Front" . "<p>\nHow to trap errors in emacs lisp?\n</p>\n"))
-                              ("lisp" "emacs" "programming")))
+                              ("lisp" "emacs" "programming") nil nil))
            ("Dot product" . #s(anki-editor-note
                                nil "Basic" "Mathematics"
                                (("Back" . "<p>\n<p>[$$]\\alpha \\cdot \\beta = a_1b_1 + a_2b_2 + a_3b_3[/$$]</p>\n</p>\n")
                                 ("Front" . "<p>\nHow to calculate the dot product of two vectors:\n</p>\n\n[latex]<br>\\begin{equation*}<br>\\alpha = \\{a_1, a_2, a_3\\}, \\beta = \\{b_1, b_2, b_3\\}<br>\\end{equation*}<br>[/latex]\n"))
-                               nil))
+                               nil nil nil))
            )))
     (save-window-excursion
       (with-current-buffer (anki-editor-test--test-org-buffer "examples.org")

--- a/anki-editor-tests.el
+++ b/anki-editor-tests.el
@@ -159,17 +159,21 @@ Front content
       (anki-editor-test--go-to-headline "Simple note")
       (anki-editor-test--setup)
       (unwind-protect
-          (should (equal
-                   (anki-editor-note-at-point)
-                   #s(anki-editor-note nil "Basic" "Tests"
-                                       (("Back" . "<p>
+          (let ((expected-note
+                 #s(anki-editor-note nil "Basic" "Tests"
+                                     (("Back" . "<p>
 Lorem
 </p>
 ")
-                                        ("Front" . "<p>
+                                      ("Front" . "<p>
 Simple note body
 </p>
-")) nil nil nil)))
+")) nil nil nil))
+                (note-at-point (anki-editor-note-at-point)))
+            (setf (anki-editor-note-fields note-at-point)
+                  (anki-editor--export-fields (anki-editor-note-fields note-at-point)))
+            (setf (anki-editor-note-marker expected-note) (point-marker))
+            (should (equal expected-note note-at-point)))
         (anki-editor-test--teardown)))))
 
 
@@ -180,27 +184,34 @@ Simple note body
       (anki-editor-test--go-to-headline "\"Front\" property field")
       (anki-editor-test--setup)
       (unwind-protect
-          (should (equal
-                   (anki-editor-note-at-point)
-                   #s(anki-editor-note nil "Basic" "Tests"
-                                       (("Back" . "<p>\nShould be included\n</p>\n")
-                                        ("Front" . "<p>\nCan one define an anki-field inside an org-mode property?</p>\n"))
-                                       nil nil nil)))
-        (anki-editor-test--teardown)))))
+          (let ((expected-note
+                 #s(anki-editor-note nil "Basic" "Tests"
+                                     (("Back" . "<p>\nShould be included\n</p>\n")
+                                      ("Front" . "<p>\nCan one define an anki-field inside an org-mode property?</p>\n"))
+                                     nil nil nil))
+                (note-at-point (anki-editor-note-at-point)))
+            (setf (anki-editor-note-fields note-at-point)
+                  (anki-editor--export-fields (anki-editor-note-fields note-at-point)))
+            (setf (anki-editor-note-marker expected-note) (point-marker))
+            (should (equal note-at-point expected-note))
+            (anki-editor-test--teardown)))))
 
-(ert-deftest test--note-at-point-for-note-with-property-field-should-override-subheading-field ()
-  "Test `anki-editor--note-at-point' should override subheading field."
-  (save-window-excursion
-    (with-current-buffer (anki-editor-test--test-org-buffer "test-files/property-fields.org")
-      (anki-editor-test--go-to-headline "\"Front\" property field with \"Front\" subheading")
-      (anki-editor-test--setup)
-      (unwind-protect
-          (should (equal
-                   (anki-editor-note-at-point)
-                   #s(anki-editor-note nil "Basic" "Tests"
-                                       (("Back" . "<p>\nShould be included\n</p>\n")
-                                        ("Front" . "<p>\nCan one define an anki-field inside an org-mode property?</p>\n"))
-                                       nil nil nil)))
+  (ert-deftest test--note-at-point-for-note-with-property-field-should-override-subheading-field ()
+    "Test `anki-editor--note-at-point' should override subheading field."
+    (save-window-excursion
+      (with-current-buffer (anki-editor-test--test-org-buffer "test-files/property-fields.org")
+        (anki-editor-test--go-to-headline "\"Front\" property field with \"Front\" subheading")
+        (anki-editor-test--setup)
+        (unwind-protect
+            (let ((expected-note #s(anki-editor-note nil "Basic" "Tests"
+                                                     (("Back" . "<p>\nShould be included\n</p>\n")
+                                                      ("Front" . "<p>\nCan one define an anki-field inside an org-mode property?</p>\n"))
+                                                     nil nil nil))
+                  (note-at-point (anki-editor-note-at-point)))
+              (setf (anki-editor-note-fields note-at-point)
+                    (anki-editor--export-fields (anki-editor-note-fields note-at-point)))
+              (setf (anki-editor-note-marker expected-note) (point-marker))
+              (should (equal note-at-point expected-note))))
         (anki-editor-test--teardown)))))
 
 
@@ -267,7 +278,12 @@ Simple note body
                            (expected-note nil))
                        (setq headline (org-entry-get (point) "ITEM"))
                        (setq note-at-point (anki-editor-note-at-point))
+                       (setf (anki-editor-note-fields note-at-point)
+                             (anki-editor--export-fields
+                              (anki-editor-note-fields note-at-point)))
                        (setq expected-note (cdr (assoc headline test-items-alist)))
+                       (setf (anki-editor-note-marker expected-note)
+                             (point-marker))
                        (should (equal note-at-point expected-note)))))))
           (anki-editor-test--teardown))))))
 

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -848,6 +848,9 @@ Return :create, :update, or :skip as appropriate."
      (anki-editor-api-enqueue 'addNote
                               :note (anki-editor-api--note note)))
     (nth 1)
+    (number-to-string)
+    (setf (anki-editor-note-id note))
+    (string-to-number)
     (anki-editor--set-note-id)))
 
 (defun anki-editor--update-note (note)
@@ -1449,7 +1452,10 @@ subtree associated with the first heading that has one."
   (interactive)
   (save-excursion
     (anki-editor--goto-nearest-note-type)
-    (anki-editor--push-note (anki-editor-note-at-point))
+    (let ((note-at-point (anki-editor-note-at-point)))
+      (anki-editor--push-note note-at-point)
+      (anki-editor--set-note-hash
+       (anki-editor--calc-note-hash note-at-point)))
     (message "Successfully pushed note at point to Anki.")))
 
 (defun anki-editor-push-new-notes (&optional scope)

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -1201,17 +1201,18 @@ of that heading."
             ((zerop (length anki-editor--note-markers))
              "Nothing to push")
             ((zerop failed)
-             (format (concat "Successfully processed %d notes."
-                             "Created %d, Updated %d, Skipped %d.")
+             (format (concat "Processed %d notes. "
+                             "| Created: %d | Updated %d | Skipped %d |")
                      count created updated skipped))
             (t
-             (format (concat "Successfully processed %d notes."
-                             "Created %d, Updated %d, Skipped %d, Failed %d."
-                             "Check property drawers for details. "
+             (format (concat "Processed %d notes. "
+                             "| Created: %d | Updated: %d | Skipped: %d | %s |"
+                             "\nCheck property drawers for details. "
                              "\nWhen you have fixed those issues, "
                              "try re-push the failed ones with "
                              "\n`anki-editor-retry-failed-notes'.")
-                     count created updated skipped failed))))))
+                     count created updated skipped
+                     (propertize (format "Failed: %d" failed) 'face '(:foreground "red"))))))))
     ;; clean up markers
     (cl-loop for m in anki-editor--note-markers
              do (set-marker m nil)

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -66,6 +66,10 @@
   "Customizations for anki-editor."
   :group 'org)
 
+(defcustom anki-editor-export-note-fields-on-push t
+  "Whether to export the fields of a note when pushing to anki."
+  :type 'boolean)
+
 (defcustom anki-editor-break-consecutive-braces-in-latex nil
   "If non-nil, automatically separate consecutive `}' in latex by spaces.
 This prevents early closing of cloze."
@@ -919,7 +923,8 @@ Return :create, :update, or :skip as appropriate."
 
 (defun anki-editor-entry-format ()
   "Get format setting for entry at point."
-  (read (or (org-entry-get-with-inheritance anki-editor-prop-format t) "t")))
+  (read (or (org-entry-get-with-inheritance anki-editor-prop-format t)
+            (if anki-editor-export-note-fields-on-push "t" "nil"))))
 
 (defun anki-editor-toggle-format ()
   "Toggle format setting for entry at point.

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -1377,7 +1377,9 @@ of that heading."
                            (:skip (cl-incf skipped))))
                        ;; free marker
                        (set-marker marker nil))
-              (message "Sending %d notes to Anki... " (+ queued-created queued-updated))
+              (when (> (+ queued-created queued-updated) 0)
+                (message "Sending %d notes to Anki... "
+                         (+ queued-created queued-updated)))
               (let ((results nil))
                 ;; some requests can initiate follow-up requests
                 ;; so we keep processing until all queues are empty.

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -250,9 +250,9 @@ Raise an error if applicable."
 (defvar anki-editor--api-active-queue 1
   "Determines which anki-editor--api-request-queue is accepting requests.")
 (defvar anki-editor--api-request-queue-1 nil
-  "Queued requests for anki-editor-api-call-multi.")
+  "Queued requests for anki-editor-api-dispatch-queue.")
 (defvar anki-editor--api-request-queue-2 nil
-  "Queued requests for anki-editor-api-call-multi.")
+  "Queued requests for anki-editor-api-dispatch-queue.")
 
 (defun anki-editor-api--make-queued-request (request success error)
   (list :request request :success success :error error))
@@ -293,8 +293,11 @@ and ERROR callbacks will be processed as appropriate."
 
 (defun anki-editor-api-dispatch-queue ()
   "Dispatch requests enqueued with anki-editor-api-enqueue-request.
-Returns a list of the return values from calling the :success or :error
-callback on each result as appropriate."
+Returns a property list containing the keys :count, :successes,
+:errors, and :results. These keys correspond to the count of
+responses processed, the count of successful responses, the count
+of unsuccessful responses, and a list of the return values from
+the passed callbacks."
   (when-let (queue (anki-editor-api--get-active-queue))
     (anki-editor-api--toggle-active-queue)
     (let* ((requests (reverse queue))


### PR DESCRIPTION
### Summary

The improvements boil down to three things:
1. Successful updates to anki now hash note contents and save the hash in an org property on the note. Subsequent pushes hash the current contents and compare against the saved hash, only pushing to anki when a difference is found.
2. Pushes now defer exporting note fields until it's determined that the note will be sent to anki. Also added a variable to make it easy to turn off exporting by default.
3. Pushes now batch up all api requests and send them as one call to anki at the end of processing. Some actions queue up further api calls upon successful completion, which are also all batched up for a second round of requests to the api, and so on until there are no more queued requests to process.

The end result is somewhere between a 50% and 100% speed up on pushing new cards and a virtually unlimited speed up when pushing a large corpus of existing notes, most of which haven't changed.

### Benchmarks
#### Scenario: 100 new cards, no exporting
Old version
```
anki-editor-push-notes                                        1           7.136857152   7.136857152
anki-editor--push-note                                        100         6.6887327069  0.0668873270
anki-editor--create-note                                      100         6.6881397940  0.0668813979
anki-editor-api-call-result                                   102         5.6642092069  0.0555314628
anki-editor-api-call                                          102         5.6635051920  0.0555245607
anki-editor--fetch                                            102         5.6286292289  0.0551826394
anki-editor--set-note-id                                      100         1.193064913   0.0119306491
anki-editor-note-at-point                                     100         0.1189815169  0.0011898151
```

New version
```
anki-editor-push-notes                                        1           3.495925223   3.495925223
anki-editor-api-dispatch-queue                                1           3.139614536   3.139614536
anki-editor--set-note-id                                      100         1.2845784160  0.0128457841
anki-editor--set-note-hash                                    100         1.1354448910  0.0113544489
anki-editor-api-call                                          3           0.731150873   0.2437169576
anki-editor--fetch                                            3           0.724643433   0.241547811
anki-editor-api-call-result                                   2           0.13582163    0.067910815
anki-editor--draw-progress-bar                                300         0.1276257599  0.0004254191
```
#### Scenario: 99 unchanged cards, 1 changed, no exporting
Old version
```
anki-editor-push-notes                                        1           12.861965705  12.861965705
anki-editor-api-call-result                                   202         12.598017311  0.0623664223
anki-editor-api-call                                          202         12.596747883  0.0623601380
anki-editor--fetch                                            202         12.524509685  0.0620025231
anki-editor--push-note                                        100         12.481670745  0.1248167074
anki-editor--update-note                                      100         12.481030434  0.1248103043
```

New version
```
anki-editor-push-notes                                        1           0.581315192   0.581315192
anki-editor-api-call                                          5           0.321204258   0.0642408516
anki-editor--fetch                                            5           0.319538121   0.0639076242
anki-editor-api-dispatch-queue                                3           0.2021955790  0.0673985263
anki-editor-api-call-result                                   2           0.130345123   0.0651725615
```
#### Scenario: 100 new cards, exporting
Old version
```
anki-editor-push-notes                                        1           15.628968179  15.628968179
anki-editor-note-at-point                                     100         7.9138981689  0.0791389816
anki-editor--export-string                                    200         7.7812412609  0.0389062063
anki-editor--push-note                                        100         7.423356627   0.0742335662
anki-editor--create-note                                      100         7.4226246080  0.0742262460
anki-editor-api-call-result                                   102         6.6357773909  0.0650566410
anki-editor-api-call                                          102         6.6351431740  0.0650504232
anki-editor--fetch                                            102         6.601921938   0.0647247248
anki-editor--set-note-id                                      100         0.9226533030  0.0092265330
```
New version
```
anki-editor-push-notes                                        1           10.63572962   10.63572962
anki-editor--process-note                                     100         7.0228366299  0.0702283662
anki-editor--enqueue-create-note                              100         7.0101047570  0.0701010475
anki-editor-api--note                                         100         7.0059367729  0.0700593677
anki-editor--export-fields                                    100         7.0047806490  0.0700478064
anki-editor--export-string                                    200         6.997352285   0.0349867614
anki-editor-api-dispatch-queue                                1           3.284697947   3.284697947
anki-editor--set-note-id                                      100         1.5486320809  0.0154863208
anki-editor--set-note-hash                                    100         0.9447315479  0.0094473154
anki-editor-api-call                                          3           0.781342395   0.260447465
anki-editor--fetch                                            3           0.774590947   0.2581969823
anki-editor--draw-progress-bar                                300         0.1329500850  0.0004431669
anki-editor-api-call-result                                   2           0.115276907   0.0576384535
```
#### Scenario: 99 unchanged cards, 1 changed, exporting
Old version
```
anki-editor-push-notes                                        1           19.133579662  19.133579662
anki-editor-api-call-result                                   202         11.680356543  0.0578235472
anki-editor-api-call                                          202         11.679067128  0.0578171640
anki-editor--fetch                                            202         11.611660435  0.0574834675
anki-editor--push-note                                        100         11.545812984  0.1154581298
anki-editor--update-note                                      100         11.545062166  0.1154506216
anki-editor-note-at-point                                     100         7.2823560520  0.0728235605
anki-editor--export-string                                    200         6.9578029099  0.0347890145
```
New version
```
anki-editor-push-notes                                        1           0.544985199   0.544985199
anki-editor-api-call                                          5           0.275446766   0.0550893532
anki-editor--fetch                                            5           0.273730727   0.0547461454
anki-editor-api-dispatch-queue                                3           0.165724849   0.0552416163
anki-editor-api-call-result                                   2           0.1212798710  0.0606399355
```
#### Informal Scenario: 999 unchanged notes, 1 changed
I didn't think to instrument this one, unfortunately but the new version took about 2s, whereas, judging by the benchmarks above (and assuming the old version is linear-time in the number of notes...) it would be about 120s in the old version.

#### Methodology
I used elp to get these benchmarks and included every function with more than .1s total runtime. The columns from left to right are: function name, times called, total runtime, runtime per call.

### Future
Exporting is now the major factor by far when sending cards, making up about 70% of the total runtime. Setting the note ID and hash combine for another 25%.

Most of the exporting work seems to be done on the org side so I don't know how realistic it will be to tune that. Maybe it's possible to tweak how we make the calls though.

In any case it's much easier to use anki-editor for maintaining large collections of notes now.