### PR TITLE
Implement optional field swap when both are missing

### DIFF
--- a/anki-editor-tests.el
+++ b/anki-editor-tests.el
@@ -271,7 +271,80 @@ Simple note body
                        (should (equal note-at-point expected-note)))))))
           (anki-editor-test--teardown))))))
 
+(ert-deftest test--anki-editor--map-fields-cloze-default ()
+  "Test `anki-editor--map-fields' should process default note."
+  (save-window-excursion
+    (with-current-buffer (anki-editor-test--test-org-buffer "test-files/cloze.org")
+      (anki-editor-test--setup)
+      (unwind-protect
+          (let* ((anki-editor-swap-two-fields nil)
+                 (note (progn
+                         (anki-editor-test--go-to-headline "Default note")
+                         (anki-editor-note-at-point)))
+                 (fields (anki-editor-note-fields note))
+                 (first-field (nth 0 fields))
+                 (second-field (nth 1 fields)))
+            (should (and (string= "Back Extra" (car first-field))
+                         (string-match "Default note" (cdr first-field))))
+            (should (and (string= "Text" (car second-field))
+                         (string-match "This is the {{c1::content}}." (cdr second-field)))))
+        (anki-editor-test--teardown)))))
 
+(ert-deftest test--anki-editor--map-fields-cloze-default-with-extra ()
+  "Test `anki-editor--map-fields' should process default note with extra."
+  (save-window-excursion
+    (with-current-buffer (anki-editor-test--test-org-buffer "test-files/cloze.org")
+      (anki-editor-test--setup)
+      (unwind-protect
+          (let* ((anki-editor-swap-two-fields nil)
+                 (note (progn
+                         (anki-editor-test--go-to-headline "Default note with Extra")
+                         (anki-editor-note-at-point)))
+                 (fields (anki-editor-note-fields note))
+                 (first-field (nth 0 fields))
+                 (second-field (nth 1 fields)))
+            (should (and (string= "Back Extra" (car first-field))
+                         (string-match "This is the extra content." (cdr first-field))))
+            (should (and (string= "Text" (car second-field))
+                         (string-match "This is the {{c1::content}}." (cdr second-field)))))
+        (anki-editor-test--teardown)))))
+
+(ert-deftest test--anki-editor--map-fields-cloze-should-not-swap-heading-and-content-before-subheadings ()
+  "Test `anki-editor--map-fields' should not swap heading and content before subheadings."
+  (save-window-excursion
+    (with-current-buffer (anki-editor-test--test-org-buffer "test-files/cloze.org")
+      (unwind-protect
+          (let* ((anki-editor-swap-two-fields nil)
+                 (note (progn
+                         (anki-editor-test--go-to-headline "Text subheading omitted")
+                         (anki-editor-note-at-point)))
+                 (fields (anki-editor-note-fields note))
+                 (first-field (nth 0 fields))
+                 (second-field (nth 1 fields)))
+            (should (and (string= "Extra" (car first-field))
+                         (string-match "This is the {{c1::content}}." (cdr first-field))))
+            (should (and (string= "Text" (car second-field))
+                         (string-match "Text subheading omitted" (cdr second-field)))))
+        (anki-editor-test--teardown)))))
+
+(ert-deftest test--anki-editor--map-fields-cloze-should-swap-heading-and-content-before-subheadings ()
+  "Test `anki-editor--map-fields' should swap heading and content before subheadings."
+  (save-window-excursion
+    (with-current-buffer (anki-editor-test--test-org-buffer "test-files/cloze.org")
+      (anki-editor-test--setup)
+      (unwind-protect
+          (let* ((anki-editor-swap-two-fields '("Cloze"))
+                 (note (progn
+                         (anki-editor-test--go-to-headline "Text subheading omitted")
+                         (anki-editor-note-at-point)))
+                 (fields (anki-editor-note-fields note))
+                 (first-field (nth 0 fields))
+                 (second-field (nth 1 fields)))
+            (should (and (string= "Back Extra" (car first-field))
+                         (string-match "Text subheading omitted" (cdr first-field))))
+            (should (and (string= "Text" (car second-field))
+                         (string-match "This is the {{c1::content}}." (cdr second-field)))))
+        (anki-editor-test--teardown)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; anki-editor-tests.el ends here

--- a/anki-editor-tests.el
+++ b/anki-editor-tests.el
@@ -313,6 +313,7 @@ Simple note body
   "Test `anki-editor--map-fields' should not swap heading and content before subheadings."
   (save-window-excursion
     (with-current-buffer (anki-editor-test--test-org-buffer "test-files/cloze.org")
+      (anki-editor-test--setup)
       (unwind-protect
           (let* ((anki-editor-swap-two-fields nil)
                  (note (progn
@@ -321,7 +322,7 @@ Simple note body
                  (fields (anki-editor-note-fields note))
                  (first-field (nth 0 fields))
                  (second-field (nth 1 fields)))
-            (should (and (string= "Extra" (car first-field))
+            (should (and (string= "Back Extra" (car first-field))
                          (string-match "This is the {{c1::content}}." (cdr first-field))))
             (should (and (string= "Text" (car second-field))
                          (string-match "Text subheading omitted" (cdr second-field)))))

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -933,95 +933,95 @@ When the `subheading-fields' don't match the `note-type's fields,
 map missing fields to the `heading' and/or `content-before-subheading'.
 Return a list of cons of (FIELD-NAME . FIELD-CONTENT)."
   (anki-editor--with-collection-data-updated
-    (let* ((model-fields (alist-get
-                          note-type anki-editor--model-fields
-                          nil nil #'string=))
-           (property-fields (anki-editor--property-fields model-fields))
-           (named-fields (seq-uniq (append property-fields subheading-fields)
-                                   (lambda (left right)
-                                     (string= (car left) (car right)))))
-           (fields-matching (cl-intersection
-                             model-fields (mapcar #'car named-fields)
-                             :test #'string=))
-           (fields-missing (cl-set-difference
+   (let* ((model-fields (alist-get
+                         note-type anki-editor--model-fields
+                         nil nil #'string=))
+          (property-fields (anki-editor--property-fields model-fields))
+          (named-fields (seq-uniq (append property-fields subheading-fields)
+                                  (lambda (left right)
+                                    (string= (car left) (car right)))))
+          (fields-matching (cl-intersection
                             model-fields (mapcar #'car named-fields)
                             :test #'string=))
-           (fields-extra (cl-set-difference
-                          (mapcar #'car named-fields) model-fields
-                          :test #'string=))
-           (fields (cl-loop for f in fields-matching
-                            collect (cons f (alist-get
-                                             f named-fields
-                                             nil nil #'string=))))
-           (heading-format anki-editor-prepend-heading-format))
-      (cond ((equal 0 (length fields-missing))
-             (when (< 0 (length fields-extra))
-               (user-error "Failed to map all named fields")))
-            ((equal 1 (length fields-missing))
-             (if (equal 0 (length fields-extra))
-                 (if (equal "" (string-trim content-before-subheading))
-                     (push (cons (car fields-missing) heading)
-                           fields)
-                   (if prepend-heading
-                       (push (cons (car fields-missing)
-                                   (concat
-                                    (format heading-format heading)
-                                    content-before-subheading))
-                             fields)
-                     (push (cons (car fields-missing)
-                                 content-before-subheading)
-                           fields)))
-               (if (equal "" (string-trim content-before-subheading))
-                   (push (cons (car fields-missing)
-                               (anki-editor--concat-fields
-                                fields-extra subheading-fields level))
-                         fields)
-                 (if prepend-heading
-                     (push (cons (car fields-missing)
-                                 (concat
-                                  (format heading-format heading)
-                                  content-before-subheading
-                                  (anki-editor--concat-fields
-                                   fields-extra subheading-fields
-                                   level)))
-                           fields)
-                   (push (cons (car fields-missing)
-                               (concat content-before-subheading
-                                       (anki-editor--concat-fields
-                                        fields-extra subheading-fields
-                                        level)))
-                         fields)))))
-            ((equal 2 (length fields-missing))
-             (if (equal 0 (length fields-extra))
-                 (progn
-                   (push (cons (nth 1 fields-missing)
-                               content-before-subheading)
-                         fields)
-                   (push (cons (car fields-missing)
-                               heading)
-                         fields))
-               (if (equal "" (string-trim content-before-subheading))
-                   (progn
-                     (push (cons (nth 1 fields-missing)
+          (fields-missing (cl-set-difference
+                           model-fields (mapcar #'car named-fields)
+                           :test #'string=))
+          (fields-extra (cl-set-difference
+                         (mapcar #'car named-fields) model-fields
+                         :test #'string=))
+          (fields (cl-loop for f in fields-matching
+                           collect (cons f (alist-get
+                                            f named-fields
+                                            nil nil #'string=))))
+          (heading-format anki-editor-prepend-heading-format))
+     (cond ((equal 0 (length fields-missing))
+            (when (< 0 (length fields-extra))
+              (user-error "Failed to map all named fields")))
+           ((equal 1 (length fields-missing))
+            (if (equal 0 (length fields-extra))
+                (if (equal "" (string-trim content-before-subheading))
+                    (push (cons (car fields-missing) heading)
+                          fields)
+                  (if prepend-heading
+                      (push (cons (car fields-missing)
+                                  (concat
+                                   (format heading-format heading)
+                                   content-before-subheading))
+                            fields)
+                    (push (cons (car fields-missing)
+                                content-before-subheading)
+                          fields)))
+              (if (equal "" (string-trim content-before-subheading))
+                  (push (cons (car fields-missing)
+                              (anki-editor--concat-fields
+                               fields-extra subheading-fields level))
+                        fields)
+                (if prepend-heading
+                    (push (cons (car fields-missing)
+                                (concat
+                                 (format heading-format heading)
+                                 content-before-subheading
                                  (anki-editor--concat-fields
-                                  fields-extra subheading-fields level))
-                           fields)
-                     (push (cons (car fields-missing)
-                                 heading)
-                           fields))
-                 (progn
-                   (push (cons (nth 1 fields-missing)
-                               (concat content-before-subheading
-                                       (anki-editor--concat-fields
-                                        fields-extra subheading-fields level)))
-                         fields)
-                   (push (cons (car fields-missing)
-                               heading)
-                         fields)))))
-            ((< 2 (length fields-missing))
-             (user-error (concat "Cannot map note fields: "
-                                 "more than two fields missing"))))
-      fields)))
+                                  fields-extra subheading-fields
+                                  level)))
+                          fields)
+                  (push (cons (car fields-missing)
+                              (concat content-before-subheading
+                                      (anki-editor--concat-fields
+                                       fields-extra subheading-fields
+                                       level)))
+                        fields)))))
+           ((equal 2 (length fields-missing))
+            (if (equal 0 (length fields-extra))
+                (progn
+                  (push (cons (nth 1 fields-missing)
+                              content-before-subheading)
+                        fields)
+                  (push (cons (car fields-missing)
+                              heading)
+                        fields))
+              (if (equal "" (string-trim content-before-subheading))
+                  (progn
+                    (push (cons (nth 1 fields-missing)
+                                (anki-editor--concat-fields
+                                 fields-extra subheading-fields level))
+                          fields)
+                    (push (cons (car fields-missing)
+                                heading)
+                          fields))
+                (progn
+                  (push (cons (nth 1 fields-missing)
+                              (concat content-before-subheading
+                                      (anki-editor--concat-fields
+                                       fields-extra subheading-fields level)))
+                        fields)
+                  (push (cons (car fields-missing)
+                              heading)
+                        fields)))))
+           ((< 2 (length fields-missing))
+            (user-error (concat "Cannot map note fields: "
+                                "more than two fields missing"))))
+     fields)))
 
 (defun anki-editor--concat-fields (field-names field-alist level)
   "Concat field names and content of fields in list `field-names'."
@@ -1129,36 +1129,36 @@ of that heading."
               (failed 0))
           (save-excursion
             (anki-editor--with-collection-data-updated
-              (cl-loop with bar-width = 30
-                       for marker in anki-editor--note-markers
-                       for progress = (/ (float (cl-incf count))
-                                         (length anki-editor--note-markers))
-                       do
-                       (goto-char marker)
-                       (message
-                        "Uploading notes in buffer %s%s [%s%s] %d/%d (%.2f%%)"
-                        (marker-buffer marker)
-                        (if (zerop failed)
-                            ""
-                          (propertize (format " %d failed" failed)
-                                      'face `(:foreground "red")))
-                        (make-string (truncate (* bar-width progress))
-                                     ?#)
-                        (make-string (- bar-width
-                                        (truncate (* bar-width
-                                                     progress)))
-                                     ?.)
-                        count
-                        (length anki-editor--note-markers)
-                        (* 100 progress))
-                       (anki-editor--clear-failure-reason)
-                       (condition-case-unless-debug err
-                           (anki-editor--push-note (anki-editor-note-at-point))
-                         (error (cl-incf failed)
-                                (anki-editor--set-failure-reason
-                                 (error-message-string err))))
-                       ;; free marker
-                       (set-marker marker nil))))
+             (cl-loop with bar-width = 30
+                      for marker in anki-editor--note-markers
+                      for progress = (/ (float (cl-incf count))
+                                        (length anki-editor--note-markers))
+                      do
+                      (goto-char marker)
+                      (message
+                       "Uploading notes in buffer %s%s [%s%s] %d/%d (%.2f%%)"
+                       (marker-buffer marker)
+                       (if (zerop failed)
+                           ""
+                         (propertize (format " %d failed" failed)
+                                     'face `(:foreground "red")))
+                       (make-string (truncate (* bar-width progress))
+                                    ?#)
+                       (make-string (- bar-width
+                                       (truncate (* bar-width
+                                                    progress)))
+                                    ?.)
+                       count
+                       (length anki-editor--note-markers)
+                       (* 100 progress))
+                      (anki-editor--clear-failure-reason)
+                      (condition-case-unless-debug err
+                          (anki-editor--push-note (anki-editor-note-at-point))
+                        (error (cl-incf failed)
+                               (anki-editor--set-failure-reason
+                                (error-message-string err))))
+                      ;; free marker
+                      (set-marker marker nil))))
           (message
            (cond
             ((zerop (length anki-editor--note-markers))

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -167,6 +167,12 @@ use Anki's builtin LaTeX support."
   :type '(choice (string :tag "Use this string for the class' name.")
                  (const :tag "Do not create an extra div for display math." nil)))
 
+(defcustom anki-editor-swap-two-fields nil
+  "For note types in this list, swap fields
+`content-before-subheading' and `heading' when both model fields
+are missing."
+  :type '(repeat string))
+
 ;;; AnkiConnect
 
 (defconst anki-editor-api-version 6)
@@ -953,7 +959,8 @@ Return a list of cons of (FIELD-NAME . FIELD-CONTENT)."
                            collect (cons f (alist-get
                                             f named-fields
                                             nil nil #'string=))))
-          (heading-format anki-editor-prepend-heading-format))
+          (heading-format anki-editor-prepend-heading-format)
+          (field-swap (if (member note-type anki-editor-swap-two-fields) 1 0)))
      (cond ((equal 0 (length fields-missing))
             (when (< 0 (length fields-extra))
               (user-error "Failed to map all named fields")))
@@ -994,28 +1001,28 @@ Return a list of cons of (FIELD-NAME . FIELD-CONTENT)."
            ((equal 2 (length fields-missing))
             (if (equal 0 (length fields-extra))
                 (progn
-                  (push (cons (nth 1 fields-missing)
+                  (push (cons (nth (- 1 field-swap) fields-missing)
                               content-before-subheading)
                         fields)
-                  (push (cons (car fields-missing)
+                  (push (cons (nth (- field-swap 0) fields-missing)
                               heading)
                         fields))
               (if (equal "" (string-trim content-before-subheading))
                   (progn
-                    (push (cons (nth 1 fields-missing)
+                    (push (cons (nth (- 1 field-swap) fields-missing)
                                 (anki-editor--concat-fields
                                  fields-extra subheading-fields level))
                           fields)
-                    (push (cons (car fields-missing)
+                    (push (cons (nth (- field-swap 0) fields-missing)
                                 heading)
                           fields))
                 (progn
-                  (push (cons (nth 1 fields-missing)
+                  (push (cons (nth (- 1 field-swap) fields-missing)
                               (concat content-before-subheading
                                       (anki-editor--concat-fields
                                        fields-extra subheading-fields level)))
                         fields)
-                  (push (cons (car fields-missing)
+                  (push (cons (nth (- field-swap 0) fields-missing)
                               heading)
                         fields)))))
            ((< 2 (length fields-missing))

--- a/test-files/cloze.org
+++ b/test-files/cloze.org
@@ -1,0 +1,29 @@
+* Default note
+:PROPERTIES:
+:ANKI_NOTE_TYPE: Cloze
+:ANKI_DECK: Tests
+:END:
+** Text
+
+This is the {{c1::content}}.
+
+* Default note with Extra
+:PROPERTIES:
+:ANKI_NOTE_TYPE: Cloze
+:ANKI_DECK: Tests
+:END:
+** Text
+
+This is the {{c1::content}}.
+
+** Extra
+
+This is the extra content.
+
+* Text subheading omitted
+:PROPERTIES:
+:ANKI_NOTE_TYPE: Cloze
+:ANKI_DECK: Tests
+:END:
+
+This is the {{c1::content}}.


### PR DESCRIPTION
Addressing <https://github.com/anki-editor/anki-editor/issues/65>, this PR implements the optional field swap when both fields of a note type are not explicitly supplied as subheadings in an anki note. For this, it introduces

-   a new custom variable `anki-editor-swap-two-fields` which stores note types for which the field swap goes in effect
-   an update to the `anki-editor–map-fields` logic such that with a note with note type in `anki-editor-swap-two-fields`, we swap the order of assignment of `heading` and `content-before-subheading` (or the equivalent content of this)

With `anki-editor-swap-two-fields` set to `nil` (which should become the default), the current logic remains unaffected.