### PR TITLE
(fix): Use org-export-exclude-tags in short-form Anki notes

### DIFF
--- a/anki-editor-tests.el
+++ b/anki-editor-tests.el
@@ -381,5 +381,107 @@ Simple note body
     (should (and (string= "Text" (car second-field))
                  (string-match "This is the {{c1::content}}." (cdr second-field))))))
 
+(anki-editor-deftest test--anki-editor--build-fields-should-not-use-exclude-tags-with-nested-subheadings ()
+  :doc "Test `anki-editor--build-fields' should not use exclude tags with nested subheadings."
+  :in "test-files/export-exclude-tags.org"
+  :test
+  (let* ((org-export-exclude-tags nil)
+         (note (progn
+                 (anki-editor-test--go-to-headline "Basic Anki note")
+                 (anki-editor-note-at-point)))
+         (fields (anki-editor-note-fields note))
+         (first-field (nth 0 fields))
+         (second-field (nth 1 fields)))
+    (should (and (string= "Back" (car first-field))
+                 (string-match "This is back" (cdr first-field))
+                 (string-match "This will be included in the content if" (cdr first-field))))
+    (should (and (string= "Front" (car second-field))
+                 (string-match "This is front" (cdr second-field))))))
+
+(anki-editor-deftest test--anki-editor--build-fields-should-use-exclude-tags-with-nested-subheadings ()
+  :doc "Test `anki-editor--build-fields' should use exclude tags with nested subheadings."
+  :in "test-files/export-exclude-tags.org"
+  :test
+  (let* ((org-export-exclude-tags '("noexport"))
+         (note (progn
+                 (anki-editor-test--go-to-headline "Basic Anki note")
+                 (anki-editor-note-at-point)))
+         (fields (anki-editor-note-fields note))
+         (first-field (nth 0 fields))
+         (second-field (nth 1 fields)))
+    (should (and (string= "Back" (car first-field))
+                 (string-match "This is back" (cdr first-field))
+                 (not (string-match "This will be included in the content if" (cdr first-field)))))
+    (should (and (string= "Front" (car second-field))
+                 (string-match "This is front" (cdr second-field))))))
+
+(anki-editor-deftest test--anki-editor--build-fields-should-not-use-exclude-tags-in-short-form-basic ()
+  :doc "Test `anki-editor--build-fields' should not use exclude tags in short form basic."
+  :in "test-files/export-exclude-tags.org"
+  :test
+  (let* ((org-export-exclude-tags nil)
+         (note (progn
+                 (anki-editor-test--go-to-headline "Basic Anki note in short form")
+                 (anki-editor-note-at-point)))
+         (fields (anki-editor-note-fields note))
+         (first-field (nth 0 fields))
+         (second-field (nth 1 fields)))
+    (should (and (string= "Back" (car first-field))
+                 (string-match "Content" (cdr first-field))
+                 (string-match "This will be included in the content if" (cdr first-field))))
+    (should (and (string= "Front" (car second-field))
+                 (string-match "Basic Anki note in short form" (cdr second-field))))))
+
+(anki-editor-deftest test--anki-editor--build-fields-should-use-exclude-tags-in-short-form-basic ()
+  :doc "Test `anki-editor--build-fields' should use exclude tags in short form basic."
+  :in "test-files/export-exclude-tags.org"
+  :test
+  (let* ((org-export-exclude-tags '("noexport"))
+         (note (progn
+                 (anki-editor-test--go-to-headline "Basic Anki note in short form")
+                 (anki-editor-note-at-point)))
+         (fields (anki-editor-note-fields note))
+         (first-field (nth 0 fields))
+         (second-field (nth 1 fields)))
+    (should (and (string= "Back" (car first-field))
+                 (string-match "Content" (cdr first-field))
+                 (not (string-match "This will be included in the content if" (cdr first-field)))))
+    (should (and (string= "Front" (car second-field))
+                 (string-match "Basic Anki note in short form" (cdr second-field))))))
+
+(anki-editor-deftest test--anki-editor--build-fields-should-not-use-exclude-tags-in-short-form-cloze ()
+  :doc "Test `anki-editor--build-fields' should not use exclude tags in short form Cloze."
+  :in "test-files/export-exclude-tags.org"
+  :test
+  (let* ((org-export-exclude-tags nil)
+         (note (progn
+                 (anki-editor-test--go-to-headline "Cloze Anki note in short form")
+                 (anki-editor-note-at-point)))
+         (fields (anki-editor-note-fields note))
+         (first-field (nth 0 fields))
+         (second-field (nth 1 fields)))
+    (should (and (string= "Back Extra" (car first-field))
+                 (string-match "Content" (cdr first-field))
+                 (string-match "This will be included in the content if" (cdr first-field))))
+    (should (and (string= "Text" (car second-field))
+                 (string-match "Cloze Anki note in short form" (cdr second-field))))))
+
+(anki-editor-deftest test--anki-editor--build-fields-should-use-exclude-tags-in-short-form-cloze ()
+  :doc "Test `anki-editor--build-fields' should use exclude tags in short form Cloze."
+  :in "test-files/export-exclude-tags.org"
+  :test
+  (let* ((org-export-exclude-tags '("noexport"))
+         (note (progn
+                 (anki-editor-test--go-to-headline "Cloze Anki note in short form")
+                 (anki-editor-note-at-point)))
+         (fields (anki-editor-note-fields note))
+         (first-field (nth 0 fields))
+         (second-field (nth 1 fields)))
+    (should (and (string= "Back Extra" (car first-field))
+                 (string-match "Content" (cdr first-field))
+                 (not (string-match "This will be included in the content if" (cdr first-field)))))
+    (should (and (string= "Text" (car second-field))
+                 (string-match "Cloze Anki note in short form" (cdr second-field))))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; anki-editor-tests.el ends here

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -890,6 +890,9 @@ Return a list of cons of (FIELD-NAME . FIELD-CONTENT)."
                                  ;; scope is `tree'
                                  (min (point-max) end)))
                            "")
+             when (not (cl-intersection (org-export-get-tags element nil nil t)
+                                        org-export-exclude-tags
+                                        :test #'string-equal-ignore-case))
              ;; for content = (anki-editor--export-string raw format)
              ;; collect (cons heading content)
              collect (cons heading raw)

--- a/test-files/export-exclude-tags.org
+++ b/test-files/export-exclude-tags.org
@@ -1,0 +1,40 @@
+* Basic Anki note
+:PROPERTIES:
+:ANKI_NOTE_TYPE: Basic
+:ANKI_DECK: Tests
+:END:
+** Front
+
+This is front.
+
+** Back
+
+This is back.
+
+*** Note :noexport:
+
+This will be included in the content if ~org-export-exclude-tags~ is not set.
+
+* Basic Anki note in short form
+:PROPERTIES:
+:ANKI_NOTE_TYPE: Basic
+:ANKI_DECK: Tests
+:END:
+
+Content.
+
+** Note :noexport:
+
+This will be included in the content if ~org-export-exclude-tags~ is not set.
+
+* Cloze Anki note in short form
+:PROPERTIES:
+:ANKI_NOTE_TYPE: Cloze
+:ANKI_DECK: Tests
+:END:
+
+Content.
+
+** Note :noexport:
+
+This will be included in the content if ~org-export-exclude-tags~ is not set.


### PR DESCRIPTION
This PR aligns the usage of `org-export-exclude-tags` on pushing Anki notes.

Recall that this custom variable is typically used with the `noexport` tag, such that the (sub)headings in Org documents tagged with it are excluded from exports. This means that Anki notes also exclude similarly tagged subheadings when they are pushed via Anki Connect.

The issue is that this behavior is not implemented when the “short-form” Anki notes are used.

The engine already honors the setting of `org-export-exclude-tags` when the notes are structured with explicit subheadings (see the “Basic Anki note” test entry).

When the short-form is used (see the “Basic Anki note in short form” test entry), however, the subheadings tagged with a tag in `org-export-exclude-tags` do not get excluded on push. They are included regardless of `org-export-exclude-tags`.

Therefore, this PR patches the logic of Anki note field construction when short-form is in effect, so that fields are excluded when tagged by one of the `org-export-exclude-tags` entries.