### PR TITLE
Trim newlines at start and end of exported fields

### DIFF
--- a/anki-editor.el
+++ b/anki-editor.el
@@ -824,8 +824,9 @@ and else from variable `anki-editor-prepend-heading'."
          (exported-fields (mapcar (lambda (x)
                                     (cons
                                      (car x)
-                                     (anki-editor--export-string (cdr x)
-                                                                 format)))
+                                     (string-trim 
+                                      (anki-editor--export-string (cdr x)
+                                                                  format))))
                                   fields)))
     (unless deck (user-error "Missing deck"))
     (unless note-type (user-error "Missing note type"))


### PR DESCRIPTION
These newlines kill all interpolations in javascript.