### PR TITLE
Improve field mapping error message

### DIFF
--- a/anki-editor.el
+++ b/anki-editor.el
@@ -1238,7 +1238,9 @@ Return a list of cons of (FIELD-NAME . FIELD-CONTENT)."
            (has-content (not (string= "" (string-trim content-before-subheading)))))
       (cond ((equal 0 (length fields-missing))
              (when (< 0 (length fields-extra))
-               (user-error "Failed to map all named fields")))
+               (user-error (format "Failed to map all named fields for note: %s. Extra fields: %s"
+                                   heading
+                                   (mapconcat #'identity fields-extra ", ")))))
             ((equal 1 (length fields-missing))
              (push (cons (car fields-missing)
                          (if (and (not has-content) (not has-extra))


### PR DESCRIPTION
Adds note heading and list of extra fields to error message when field mapping fails.

## Changes
- Modified error in `anki-editor--build-fields` to include note heading and extra field names
- Makes it easier to identify which note and which fields are causing the issue

Before: `Failed to map all named fields`
After: `Failed to map all named fields for note: Some Note Title. Extra fields: Field1, Field2`