### PR TITLE
<question> Add direct link transcoder to export backend

### DIFF
--- a/anki-editor.el
+++ b/anki-editor.el
@@ -455,7 +455,8 @@ The result is the path to the newly stored media file."
    :parent 'html
    :name 'anki-html
    :transcoders '((latex-fragment . anki-editor--ox-latex)
-                  (latex-environment . anki-editor--ox-latex))))
+                  (latex-environment . anki-editor--ox-latex)
+                  (link . anki-editor--ox-html-link-transcoder))))
 
 (defconst anki-editor--ox-export-ext-plist
   '(:with-toc nil :with-properties nil :with-planning nil :anki-editor-mode t))
@@ -554,6 +555,13 @@ CONTENTS is nil.  INFO is a plist holding contextual information."
     (if anki-editor-break-consecutive-braces-in-latex
         (replace-regexp-in-string "}}" "} } " code)
       code)))
+
+(defun anki-editor--ox-html-link-transcoder (link contents info)
+  "Transcode LINK element to Anki-compatible HTML.
+CONTENTS is the link description.  INFO is a plist holding contextual info.
+For file links to audio files, produces [sound:filename] format.
+For other file links, stores the file and produces appropriate HTML."
+  (anki-editor--ox-html-link #'org-html-link link contents info))
 
 (defun anki-editor--ox-html-link (oldfun link desc info)
   "Export LINK and its target.


### PR DESCRIPTION
I was having issues with some headings with file:blah-123.mp3 bieng exported as `<a ...>` tag instead of anki `[sound:...]`

AI tried this and it fixed my issue.  I have not looked deeply into why this happened, just wanted to open it for discussion.

---

The backend previously relied on advice to org-html-link, but the :anki-editor-mode property from ext-plist didn't always reach the info argument when called through the parent backend chain. This caused intermittent failures where audio files appeared as <a href> tags instead of [sound:...] format.

Adding a direct link transcoder ensures the info plist always contains the expected properties, making audio handling reliable.