### PR TITLE
Add Typst math formula support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *-autoloads.el
 *-pkg.el
 *.elc
+.opencode/

--- a/README.org
+++ b/README.org
@@ -210,6 +210,32 @@ This field will be treated as RAW text.
 It will be sent to Anki exactly as written.
 #+END_SRC
 
+**** Typst Math Support
+
+anki-editor can convert Typst math syntax to LaTeX for notes that use the Anki LaTeX note type or cards with MathJax rendering.
+This allows you to write mathematical expressions in Typst syntax.
+
+*Prerequisites:*
+Install the =t2l= (Typst-to-LaTeX) executable from [[https://github.com/scipenai/tylax][github.com/scipenai/tylax]]
+and ensure it is available in your PATH or configure the =anki-editor-tylax-location= variable.
+
+*Configuration:*
+The =anki-editor-tylax-location= variable controls the path to the =t2l= executable.
+The default value is ="t2l"=, which expects the executable to be in your PATH. You can set it to a full path if needed.
+
+*Enabling Typst Math:*
+Add the property =:ANKI_MATH_TYPE: typst= to your note's property drawer (alongside =ANKI_NOTE_TYPE=).
+When this property is set, all fields in that note will have Typst math syntax converted to LaTeX before being sent to Anki.
+
+*Math Syntax:*
+- Inline math: =$formula$= (no spaces immediately after the opening =$= or before the closing =$=)
+- Display math: =$ formula $= (spaces between the =$= delimiters and the formula content)
+
+*Escaping Special Characters:*
+To include literal dollar or hash signs in your text, escape them with a backslash: =\$= and =\#=.
+The backslashes will be removed and the characters will be exported as regular characters,
+not as Typst math or directive syntax.
+
 *** Commands
 To see the docs for the most recent commands use M-x describe-function (for more info see [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Name-Help.html][Emacs Manual - Help Commands]])
 
@@ -250,6 +276,7 @@ To see the docs for the most recent commands use M-x describe-variable (for more
    | anki-editor-allow-duplicates                  | nil                    | If nil, pushing notes will fail if duplicate note is detected.                                                                                                                                    |
    | anki-editor-default-note-type                 | "Basic"                | Default note type when creating an anki-editor note in org.                                                                                                                                       |
    | anki-editor-latex-display-math-div            | nil                    | Whether to wrap latex fragments with an extra div when exporting. Either nil, for no extra wrapping, or a string value, which will be used for the class name of the wrapping div when exporting. |
+   | anki-editor-tylax-location                    | "t2l"                  | Path to the t2l executable for Typst math conversion. Set if the executable is not in the PATH.                                                                                                   |
 
 *** Functions and Macros
 

--- a/anki-editor-tests.el
+++ b/anki-editor-tests.el
@@ -552,5 +552,57 @@ Simple note body
     (should (and (string= "Text" (car second-field))
                  (string-match "This is {{c1::fast}}" (cdr second-field))))))
 
+(ert-deftest test--preprocess-typst-field-raw-skips-conversion ()
+  "Test that anki-editor--preprocess-typst-field skips conversion for # raw."
+  ;; This test doesn't require t2l - it just checks the # raw skip logic
+  (should (equal (anki-editor--preprocess-typst-field "# raw $f(x)=sqrt(1/2x)$" "Back")
+                 "# raw $f(x)=sqrt(1/2x)$"))
+  (should (equal (anki-editor--preprocess-typst-field "# raw\n$ Delta $" "Text")
+                 "# raw\n$ Delta $")))
+
+(ert-deftest test--preprocess-typst-field-converts-typst-to-latex ()
+  "Test typst to LaTeX conversion with mocked t2l executable."
+  ;; Test inline math: $f(x)=sqrt(1/2x)$
+  (cl-letf (((symbol-function 'call-process-region)
+             (lambda (start end program &optional delete display &rest args)
+               ;; Simulate t2l: delete region and insert output
+               (delete-region start end)
+               (insert "$f\\left(x\\right) =\\sqrt{\\frac{1}{2} x}$")
+               0)))
+    (should (equal (anki-editor--preprocess-typst-field "$f(x)=sqrt(1/2x)$" "Back")
+                   "$f\\left(x\\right) =\\sqrt{\\frac{1}{2} x}$")))
+
+  ;; Test display math: $ Delta $
+  (cl-letf (((symbol-function 'call-process-region)
+             (lambda (start end program &optional delete display &rest args)
+               ;; Simulate t2l: delete region and insert output
+               (delete-region start end)
+               (insert "\\[\n\\Delta\n\\]")
+               0)))
+    (should (equal (anki-editor--preprocess-typst-field "$ Delta $" "Text")
+                   "\\[\n\\Delta\n\\]"))))
+
+(ert-deftest test--preprocess-typst-field-escapes-special-chars ()
+  "Test that escaped dollar and hash signs are preserved as literals."
+  ;; Test that \$ becomes $ and \# becomes # in the output
+  ;; Mock just returns the input unchanged (simulating no math conversion needed)
+  (cl-letf (((symbol-function 'call-process-region)
+             (lambda (start end program &optional delete display &rest args)
+               ;; Simulate t2l: pass through unchanged - don't modify buffer
+               0)))
+    (should (equal (anki-editor--preprocess-typst-field "Price: \\$50 and count: \\#1" "Field")
+                   "Price: $50 and count: #1"))
+    ;; Test that both can appear together
+    (should (equal (anki-editor--preprocess-typst-field "\\$ and \\# together" "Field")
+                   "$ and # together")))
+  ;; Test with actual math - ensure math still works alongside escaped chars
+  (cl-letf (((symbol-function 'call-process-region)
+             (lambda (start end program &optional delete display &rest args)
+               (delete-region start end)
+               (insert "$x\\$ and \\# items$")
+               0)))
+    (should (equal (anki-editor--preprocess-typst-field "$x\\$ and \\# items$" "Field")
+                   "$x\\$ and \\# items$"))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; anki-editor-tests.el ends here

--- a/anki-editor.el
+++ b/anki-editor.el
@@ -216,6 +216,11 @@ of whether it changed or not."
   :type 'boolean
   :group 'anki-editor)
 
+(defcustom anki-editor-tylax-location "t2l"
+  "t2l executable for Typst math (PATH/full; \\\"\\\" disable)."
+  :type 'string
+  :group 'anki-editor)
+
 ;;; AnkiConnect
 
 (defconst anki-editor-api-version 6)
@@ -247,11 +252,11 @@ The api is borrowed from request.el."
         (unless (ignore-error json-end-of-file
                   (with-current-buffer responsebuf
                     (apply #'call-process "curl" nil t nil (list
-                                                        url
-                                                        "--silent"
-                                                        "-X" type
-                                                        "--data-binary"
-                                                        (concat "@" tempfile)))
+                                                            url
+                                                            "--silent"
+                                                            "-X" type
+                                                            "--data-binary"
+                                                            (concat "@" tempfile)))
 
                     (goto-char (point-min))
                     (when success
@@ -675,6 +680,7 @@ format the string, see `anki-editor--export-string'."
 (defconst anki-editor-prop-default-note-type "ANKI_DEFAULT_NOTE_TYPE")
 (defconst anki-editor-prop-swap-two-fields "ANKI_SWAP_TWO_FIELDS")
 (defconst anki-editor-prop-no-subheading-fields "ANKI_NO_SUBHEADING_FIELDS")
+(defconst anki-editor-prop-math-type "ANKI_MATH_TYPE")
 (defconst anki-editor-org-tag-regexp "^\\([[:alnum:]_@#%]+\\)+$")
 
 (cl-defstruct anki-editor-note
@@ -785,6 +791,14 @@ Return :create, :update, or :skip as appropriate."
   (set-buffer (marker-buffer (anki-editor-note-marker note)))
   (goto-char (anki-editor-note-marker note))
   (anki-editor--clear-failure-reason)
+  (when (string= (org-entry-get nil anki-editor-prop-math-type "") "typst")
+    (condition-case err
+        (setf (anki-editor-note-fields note)
+              (anki-editor--preprocess-typst-fields (anki-editor-note-fields note)))
+      (error
+       (anki-editor--set-failure-reason
+        (format "Typst math conversion error: %s" (error-message-string err)))
+       :skip)))
   (if (null (anki-editor-note-id note))
       (progn
         (anki-editor--enqueue-create-note note)
@@ -941,6 +955,50 @@ Return :create, :update, or :skip as appropriate."
   "Set failure reason to REASON in property drawer at point."
   (org-entry-put nil anki-editor-prop-failure-reason reason))
 
+(defun anki-editor--preprocess-typst-field (raw field-name)
+  "Convert Typst math syntax to LaTeX in RAW field using t2l.
+FIELD-NAME is used for error reporting.  Returns processed text.
+
+If the string starts with '# raw', return the string as is without conversion.
+
+Escaped dollar signs (\\$) and hash signs (\\#) are converted to T2L-DOLLAR
+and T2L-HASH before t2l processing, then restored to $ and # after conversion
+to distinguish literal characters from math and Typst syntax."
+  ;; Skip Typst conversion if field starts with "# raw"
+  (if (and (stringp raw) (string-prefix-p "# raw" raw))
+      raw
+    (let* ((t2l-cmd (or anki-editor-tylax-location "t2l"))
+           (full-cmd (executable-find t2l-cmd))
+           ;; Replace escaped dollars and hashes before t2l
+           (text-with-dollars (replace-regexp-in-string "\\\\\\$" "T2L-DOLLAR" raw))
+           (text-with-placeholders (replace-regexp-in-string "\\\\#" "T2L-HASH" text-with-dollars)))
+      (unless full-cmd
+        (error "t2l not found: set `anki-editor-tylax-location'"))
+      (with-temp-buffer
+        (insert text-with-placeholders)
+        (let ((exit-code (call-process-region (point-min) (point-max)
+                                              full-cmd
+                                              t    ; delete input region
+                                              t    ; output to current buffer
+                                              nil  ; don't display errors
+                                              "-d" "t2l" "--strict")))
+          (unless (eq exit-code 0)
+            (error "Typst conversion failed for field '%s' (exit code %s)" field-name exit-code))
+          (let ((output (buffer-string)))
+            (when (string-blank-p output)
+              (error "Typst conversion returned empty output for field '%s'" field-name))
+            ;; Restore T2L-HASH and T2L-DOLLAR to literal characters
+            (let ((with-hashes (replace-regexp-in-string "T2L-HASH" "#" output)))
+              (replace-regexp-in-string "T2L-DOLLAR" "$" with-hashes))))))))
+
+(defun anki-editor--preprocess-typst-fields (fields)
+  "Convert Typst math syntax to LaTeX in all note fields.
+FIELDS is an alist of (field-name . content).  Returns a new alist
+with field names unchanged and content converted using t2l."
+  (mapcar (lambda (cell)
+            (cons (car cell) (anki-editor--preprocess-typst-field (cdr cell) (car cell))))
+          fields))
+
 (defun anki-editor--clear-failure-reason ()
   "Clear failure reason in property drawer at point."
   (org-entry-delete nil anki-editor-prop-failure-reason))
@@ -956,6 +1014,7 @@ Return :create, :update, or :skip as appropriate."
      (anki-editor-all-tags))
     ((pred (string= anki-editor-prop-default-note-type))
      (anki-editor-note-types))
+    ((pred (string= anki-editor-prop-math-type)) (list "" "typst"))
     (_ nil)))
 
 (defun anki-editor-is-valid-org-tag (tag)
@@ -1206,7 +1265,7 @@ Leading whitespace, drawers, and planning content is skipped."
                    for nextelem = (progn (goto-char eoh)
                                          (org-element-at-point))
                    while (not (or (memq (org-element-type nextelem) '(headline))
-                                (eobp)))
+                                  (eobp)))
                    finally return (and eoh
                                        (if (eobp)
                                            (org-element-property :end nextelem)

--- a/test-files/typst-math.org
+++ b/test-files/typst-math.org
@@ -1,0 +1,29 @@
+* Typst math formulas
+** inline and display formulas
+:PROPERTIES:
+:ANKI_NOTE_TYPE: Basic
+:ANKI_DECK: typst math formulas
+:ANKI_MATH_TYPE: typst
+:end:
+
+*** Front
+Typst math formulas with escaped \$ and \# signs
+
+*** Back
+$f(x)=sqrt(1/2x)$
+$ Delta $
+
+** raw text
+:PROPERTIES:
+:ANKI_NOTE_TYPE: Basic
+:ANKI_DECK: typst math formulas
+:ANKI_MATH_TYPE: typst
+:end:
+
+*** Front
+Typst math formulas with # raw text
+
+*** Back
+# raw
+$f(x)=sqrt(1/2x)$
+$ Delta $


### PR DESCRIPTION
This allows users to set the `:ANKI_MATH_TYPE: typst` attribute on the note level and use Typst math formulas instead of LaTeX.

When the note is exported to Anki the Typst formulas will first be converted to LaTeX, using TyLax (t2l), before the regular export code is invoked.

This requires the t2l (TyLax) executable to be installed on the host system.